### PR TITLE
[feature] Upgrade php and wordpress version

### DIFF
--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: EPFL Accred
  * Description: Automatically sync access rights to WordPress from EPFL's institutional data repositories
- * Version:     0.16
+ * Version:     0.17
  * Author:      Dominique Quatravaux
  * Author URI:  mailto:dominique.quatravaux@epfl.ch
  */

--- a/EPFL-Accred.php
+++ b/EPFL-Accred.php
@@ -392,7 +392,7 @@ TABLE_FOOTER;
 
     function _find_unit_in_droits ($unit, $comma_separated_list_of_units)
     {
-        if (empty(trim($comma_separated_list_of_units)) or empty(trim($unit))) {
+        if (empty($comma_separated_list_of_units) or empty(trim($comma_separated_list_of_units)) or empty($unit) or empty(trim($unit))) {
             return FALSE;
         }
         $found = array_search($unit, explode(",", $comma_separated_list_of_units));

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -5,6 +5,7 @@
 namespace EPFL\Accred;
 use \WP_CLI;
 
+#[AllowDynamicProperties]
 class CLI
 {
     public function __construct ($parent_controller)

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -8,7 +8,7 @@ use \WP_CLI;
 #[AllowDynamicProperties]
 class CLI
 {
-		private $controller;
+    private $controller;
 
     public function __construct ($parent_controller)
     {

--- a/inc/cli.php
+++ b/inc/cli.php
@@ -8,6 +8,8 @@ use \WP_CLI;
 #[AllowDynamicProperties]
 class CLI
 {
+		private $controller;
+
     public function __construct ($parent_controller)
     {
         $this->controller = $parent_controller;

--- a/site.php
+++ b/site.php
@@ -27,8 +27,8 @@ function get_403_url()
     $unit_label = Controller::getInstance()->settings->get('unit');
 	
     $unit_id = Controller::getInstance()->settings->get_ldap_unit_id($unit_label);
-	    
-    $url = "/global-error/403.php?error_type=${error_type}&right=${right}&unit_id=${unit_id}&unit_label=${unit_label}";
+
+    $url = "/global-error/403.php?error_type={$error_type}&right={$right}&unit_id={$unit_id}&unit_label={$unit_label}";
 
     return $url;
 }


### PR DESCRIPTION
- PHP 8.2: ${var} string interpolation deprecated: https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated
- In PHP 8.2, dynamic Properties are deprecated. To allow them we need attribute #[AllowDynamicProperties] on the class: https://php.watch/versions/8.2/dynamic-properties-deprecated